### PR TITLE
Add missing --git in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ but this works:
 
 ```shell
 # espanso uninstall greetings-english # In case you want to upgrade
-espanso install greetings-english --external  \
+espanso install greetings-english --external --git  \
     https://github.com/katrinleinweber/espanso-greetings-english
 ```
 


### PR DESCRIPTION
Adding the missing `--git` flag in the install command, since espanso wants that.